### PR TITLE
Move requirements to setup.py and add setup.py pytest integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ htmlcov
 build
 dist
 *.egg-info
+*.eggs

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Bootstraping
 Create a venv and install development requirements::
 
   pyvenv env && source env/bin/activate
-  pip install -r dev-requirements.txt
+  pip install -e .
 
 Testing
 ~~~~~~~
@@ -47,7 +47,8 @@ Run using `py.test`::
 
 Or if you want to see coverage report::
 
-  py.test --cov=xwing --cov-report tests/
+  pip install pytest-cov
+  py.test --cov=xwing --cov-report html tests/
   open htmlcov/index.html
 
 License

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,0 @@
--r requirements.txt
-
-pytest==2.8.7
-pytest-cov==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-pyzmq==15.2.0
-gevent==1.1rc4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,20 @@ from setuptools import setup
 
 
 setup(
-    name='XWING',
+    name='xwing',
     version='0.0.1.dev0',
     url='https://github.com/victorpoluceno/xwing',
     license='ISC',
-    description='XWING is a Python library writen using that help '
+    description='Xwing is a Python library writen using that help '
         'to distribute connect to a single port to other process',
     author='Victor Poluceno',
     author_email='victorpoluceno@gmail.com',
     packages=['xwing'],
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
     install_requires=[
-        'gevent',
-        'pyzmq'
+        'gevent==1.1rc5',
+        'pyzmq==15.2.0'
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Avoid duplication of dependency definitions and leave requirements.txt to it's right usage. Also this makes easy to tun `python setup.py test` or `python setup.py test --addopts tests`.
