### PR TITLE
style: Make spawn a non node function and make initiaize shorter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,8 +25,7 @@ Sample
 
 .. code-block:: python
 
-    from xwing.mailbox import initialize, spawn_node, start_node
-    initialize()
+    from xwing.mailbox import init_node, start_node, spawn
 
     async def pong(mailbox):
         message, pid = await mailbox.recv()
@@ -36,8 +35,9 @@ Sample
         await mailbox.send(pong_pid, 'ping', mailbox.pid)
         print(await mailbox.recv())
 
-    pong_pid = spawn_node(pong)
-    spawn_node(ping, pong_pid)
+    init_node()
+    pong_pid = spawn(pong)
+    spawn(ping, pong_pid)
     start_node()
 
 Status

--- a/examples/mailbox/distributed/ping.py
+++ b/examples/mailbox/distributed/ping.py
@@ -1,5 +1,4 @@
-from xwing.mailbox import initialize, spawn, start
-initialize()
+from xwing.mailbox import init_node, start_node, spawn
 
 
 async def ping(mailbox, n, pong_node):
@@ -14,5 +13,6 @@ async def ping(mailbox, n, pong_node):
 
 if __name__ == '__main__':
     # python examples/mailbox/distributed/ping.py
+    init_node()
     spawn(ping, 3, 'pong@127.0.0.1')
-    start()
+    start_node()

--- a/examples/mailbox/distributed/pong.py
+++ b/examples/mailbox/distributed/pong.py
@@ -1,5 +1,4 @@
-from xwing.mailbox import initialize, spawn, start
-initialize()
+from xwing.mailbox import init_node, start_node, spawn
 
 
 async def pong(mailbox):
@@ -16,5 +15,6 @@ async def pong(mailbox):
 
 if __name__ == '__main__':
     # python examples/mailbox/distributed/pong.py
+    init_node()
     spawn(pong, name='pong')
-    start()
+    start_node()

--- a/examples/mailbox/ping_pong.py
+++ b/examples/mailbox/ping_pong.py
@@ -1,5 +1,4 @@
-from xwing.mailbox import initialize, spawn, start
-initialize()
+from xwing.mailbox import init_node, start_node, spawn
 
 
 async def pong(mailbox):
@@ -26,6 +25,7 @@ async def ping(mailbox, n):
 
 if __name__ == '__main__':
     # python examples/mailbox/ping_pong.py
+    init_node()
     spawn(pong, name='pong')
     spawn(ping, 3)
-    start()
+    start_node()

--- a/examples/mailbox/rpc.py
+++ b/examples/mailbox/rpc.py
@@ -1,5 +1,4 @@
-from xwing.mailbox import initialize, spawn, start
-initialize()
+from xwing.mailbox import init_node, start_node, spawn
 
 
 class Server(object):
@@ -35,10 +34,12 @@ class Client(object):
 
 if __name__ == '__main__':
     # python examples/mailbox/rpc.py
+    init_node()
+
     server = Server()
     server.run()
 
     client = Client('rpc_server@127.0.0.1')
     client.call('hello_world')
 
-    start()
+    start_node()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -7,7 +7,7 @@ import subprocess
 import logging
 logging.basicConfig(level=logging.DEBUG)
 
-from xwing.mailbox import initialize, spawn_node, start_node
+from xwing.mailbox import init_node, start_node, spawn
 from xwing.socket.client import Client
 
 FRONTEND_ADDRESS = '127.0.0.1:5555'
@@ -72,7 +72,7 @@ class TestSocket:
 class TestMailbox(object):
 
     def setup_class(self):
-        initialize()
+        init_node()
 
     def test_send_and_recv(self):
         async def echo_server(mailbox):
@@ -83,6 +83,6 @@ class TestMailbox(object):
             await mailbox.send(pid_server, 'hello', mailbox.pid)
             await mailbox.recv()
 
-        pid = spawn_node(echo_server)
-        spawn_node(echo_client, pid)
+        pid = spawn(echo_server)
+        spawn(echo_client, pid)
         start_node()

--- a/xwing/mailbox/__init__.py
+++ b/xwing/mailbox/__init__.py
@@ -47,19 +47,6 @@ class Mailbox(object):
         await self.outbound.send(pid, payload)
 
 
-node_ref = None
-
-
-def initialize():
-    global node_ref
-    node_ref = Node()
-
-
-def get_node_instance():
-    global node_ref
-    return node_ref
-
-
 class Node(object):
 
     def __init__(self, loop=None, hub_frontend='127.0.0.1',
@@ -72,7 +59,20 @@ class Node(object):
         self.tasks = []
 
 
-def spawn_node(fn, *args, name=None, node=None):
+node_ref = None
+
+
+def get_node_instance():
+    global node_ref
+    return node_ref
+
+
+def init_node():
+    global node_ref
+    node_ref = Node()
+
+
+def spawn(fn, *args, name=None, node=None):
     if not node:
         node = get_node_instance()
 


### PR DESCRIPTION
The main idea here is to make clear that spawn is not operation on the node itself, but also to keep the init/start node processes cleaner. I also fixed some examples that were broken.

@mauricioabreu this is an improvement on your initial changes, what do you think? BTW, in a near future I would like to investigate an way to automatically initialize a node, so we can supress the explicitly call to `init_node` .
